### PR TITLE
refactored docker compose & small sql init fix

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+docker-compose.yaml

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="graalvm-17 (2)" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/open_config_repo.iml" filepath="$PROJECT_DIR$/.idea/open_config_repo.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/open_config_repo.iml
+++ b/.idea/open_config_repo.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,7 @@
 services:
   kfd-config-server:
-    image: stannisl/kfd-config-server
+    build: ../config-server
+    image: config-server:latest
     container_name: config-server
     ports:
       - "8888:8888"
@@ -13,7 +14,8 @@ services:
       retries: 10
 
   kfd-discovery-service:
-    image: stannisl/kfd-discovery-service
+    build: ../discovery-server
+    image: discovery-server:latest
     container_name: discovery-service
     ports:
       - "8761:8761"
@@ -30,7 +32,8 @@ services:
       timeout: 5s
       retries: 10
   kdf-api-gateway:
-    image: stannisl/kfd-api-gateway
+    build: ../api-gateway
+    image: api-gateway:latest
     container_name: api-gateway
     environment:
       - CONFIG_SERVER_URI=http://kfd-config-server:8888
@@ -78,20 +81,21 @@ services:
     networks:
       - kfd-network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U $${USER_SERVICE_LOGIN}"]
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER}"]
       interval: 5s
       timeout: 5s
       retries: 5
 
   kfd-user-service:
-    image: stannisl/kfd-user-service
+    build: ../user-microservice
+    image: user-microservice:latest
     container_name: user-service
     ports:
       - "8081:8081"
     environment:
       CONFIG_SERVER_URI: http://kfd-config-server:8888
-      POSTGRES_USER: admin
-      POSTGRES_PASS: admin
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASS: ${POSTGRES_PASSWORD}
       DATABASE_NAME: user_service_db
       POSTGRES_JDBC_URL: kfd-postgres:5432
       DISCOVERY_SERVER_URI: http://kfd-discovery-service:8761/eureka
@@ -100,34 +104,39 @@ services:
     depends_on:
       kfd-discovery-service:
         condition: service_healthy
+      kfd-postgres:
+        condition: service_started
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8081/actuator/health"]
       interval: 10s
       timeout: 5s
       retries: 10
 
-  # kfd-board-service:
-  #   image: stannisl/kfd-board-service
-  #   container_name: board-service
-  #   ports:
-  #     - "8082:8082"
-  #   environment:
-  #     CONFIG_SERVER_URI: http://kfd-config-server:8888
-  #     POSTGRES_USER: ${USER_SERVICE_LOGIN}
-  #     POSTGRES_PASS: ${USER_SERVICE_PASS}
-  #     DATABASE_NAME: board_service
-  #     POSTGRES_JDBC_URL: kfd-postgres:5432
-  #     DISCOVERY_SERVER_URI: http://kfd-discovery-service:8761/eureka
-  #   networks:
-  #     - kfd-network
-  #   depends_on:
-  #     kfd-discovery-service:
-  #       condition: service_healthy
-  #   healthcheck:
-  #     test: ["CMD", "curl", "-f", "http://localhost:8081/actuator/health"]
-  #     interval: 10s
-  #     timeout: 5s
-  #     retries: 10
+  kfd-board-service:
+    build: ../board-microservice
+    image: board-microservice:latest
+    container_name: board-service
+    ports:
+     - "8082:8082"
+    environment:
+      CONFIG_SERVER_URI: http://kfd-config-server:8888
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASS: ${POSTGRES_PASSWORD}
+      DATABASE_NAME: board_service_db
+      POSTGRES_JDBC_URL: kfd-postgres:5432
+      DISCOVERY_SERVER_URI: http://kfd-discovery-service:8761/eureka
+    networks:
+      - kfd-network
+    depends_on:
+      kfd-discovery-service:
+        condition: service_healthy
+      kfd-postgres:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8082/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
 
 networks:
   kfd-network:

--- a/postgres-init/init.sql
+++ b/postgres-init/init.sql
@@ -1,2 +1,2 @@
-CREATE DATABASE board_service;
-CREATE DATABASE user_service_db;
+CREATE DATABASE IF NOT EXISTS board_service_db;
+CREATE DATABASE IF NOT EXISTS user_service_db;


### PR DESCRIPTION
Refactored docker compose file. 
_**Changes:**_
added services build options to build images on first docker compose run;
renamed images to make them more formal;
build path is located relatively to the docker compose considering the whole project is inside one
directory (all services are located here and open-config-repo, too); // path = ../service-folder-name; .. means going 1 level up in docker compose directory;
_**SQL init fix:**_ renamed board service bd from board_service to board_service_bd to match the user service bd;
changed CREATE DATABASE name to CREATE DATABASE IF NOT EXISTS name sql query to avoid errors;